### PR TITLE
bugfix/wtt_sensor_definition

### DIFF
--- a/case/infrasim/virtual_bmc/T46139_idic_IPMISIMSensorAccessible.json
+++ b/case/infrasim/virtual_bmc/T46139_idic_IPMISIMSensorAccessible.json
@@ -5,7 +5,7 @@
         "D51B-2U (dual 10G LoM)":{"0xc0": 1000}, "_comment": "Quanta D51",
         "S2600KP":{"0x30": 968}, "_comment": "s2600kp",
         "S2600TP":{"0x30": 968}, "_comment": "s2600tp",
-        "S2600WTT":{"0x20": 968}, "_comment": "s2600wtt",
+        "S2600WTT":{"0x30": 954}, "_comment": "s2600wtt",
         "":{"0x30": 960}, "_comment": "dell r630",
         "PowerEdge C6320":{"0x80": 980}, "_comment": "dell c6320"
     }


### PR DESCRIPTION
Fix WTT sensor and target value.
Now it is using 0x30 (System Fan 1) and target RPM is 954.
Pass local test.