### PR TITLE
enhance/T46139_add_sleep_in_bad_network

### DIFF
--- a/case/infrasim/virtual_bmc/T46139_idic_IPMISIMSensorAccessible.py
+++ b/case/infrasim/virtual_bmc/T46139_idic_IPMISIMSensorAccessible.py
@@ -58,6 +58,8 @@ class T46139_idic_IPMISIMSensorAccessible(CBaseCase):
                                 format(obj_rack.get_name(), obj_node.get_name(), bmc_obj.get_ip()))
 
                 else:
+                    # Add 1s sleep to meet lab network latency
+                    time.sleep(1)
 
                     str_rsp = bmc_ssh.send_command_wait_string(str_command='sensor info'+chr(13),
                                                                wait='IPMI_SIM',


### PR DESCRIPTION
Add 1s sleep after SSH to each node's IPMI_SIM if network in
traffic jam.
Test pass on a busy network.