### PR TITLE
enhance/block_test_if_ipmitool_fail

### DIFF
--- a/case/infrasim/virtual_bmc/T46139_idic_IPMISIMSensorAccessible.py
+++ b/case/infrasim/virtual_bmc/T46139_idic_IPMISIMSensorAccessible.py
@@ -26,6 +26,11 @@ class T46139_idic_IPMISIMSensorAccessible(CBaseCase):
 
                 # Get product name from FRU data.
                 ret, rsp = obj_node.get_bmc().ipmi.ipmitool_standard_cmd('fru print')
+                # Test fail if this nodes ipmi can't response
+                if ret != 0:
+                    self.result(BLOCK, 'Node {} on rack {} fail to response ipmitool fru print'.
+                                format(obj_node.get_name(), obj_rack.get_name()))
+                    continue
 
                 fru = {}
                 for item in rsp.split('\n'):


### PR DESCRIPTION
Some cases need to "ipmitool fru print" and get product name
and fetch specific data for testing.
If cases fail to get response from "ipmitool fru print", previous
behavior is to treat response as empty and by coinsidence R630
product name is empty now. Then case shall use R630 data for any
node which fail to response ipmitool
Current fix shall judge if "ipmitool fru print" succeeds. If fail,
case shall be blocked.

This mechnism has been verified in an environment with node's ipmi
failure.