### PR TITLE
enhacne/T33249_block_test_if_ipimtool_fail

### DIFF
--- a/case/infrasim/virtual_node/T33248_idic_IPMILocalFruPrint.py
+++ b/case/infrasim/virtual_node/T33248_idic_IPMILocalFruPrint.py
@@ -23,8 +23,16 @@ class T33248_idic_IPMILocalFruPrint(CBaseCase):
 
                 obj_bmc = obj_node.get_bmc()
                 bmc_ssh = obj_bmc.ssh
-                str_rsp = bmc_ssh.send_command_wait_string(str_command = 'ipmitool -I lanplus -H localhost -U {} -P {} fru {}'.format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)), wait = '$', int_time_out = 3, b_with_buff = False)
-                str_rsp += bmc_ssh.send_command_wait_string(str_command = 'ipmitool -I lanplus -H localhost -U {} -P {} fru print 0 {}'.format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)), wait = '$', int_time_out = 3, b_with_buff = False)
+                str_rsp = bmc_ssh.send_command_wait_string(str_command='ipmitool -I lanplus -H localhost -U {} -P {} fru {}'.
+                                                           format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)),
+                                                           wait='$',
+                                                           int_time_out=3,
+                                                           b_with_buff = False)
+                str_rsp += bmc_ssh.send_command_wait_string(str_command='ipmitool -I lanplus -H localhost -U {} -P {} fru print 0 {}'.
+                                                            format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)),
+                                                            wait='$',
+                                                            int_time_out=3,
+                                                            b_with_buff=False)
 
                 self.log('INFO', 'rsp: \n{}'.format(str_rsp))
 

--- a/case/infrasim/virtual_node/T33249_idic_IPMILocalLanPrint.py
+++ b/case/infrasim/virtual_node/T33249_idic_IPMILocalLanPrint.py
@@ -23,13 +23,25 @@ class T33249_idic_IPMILocalLanPrint(CBaseCase):
 
                 obj_bmc = obj_node.get_bmc()
                 bmc_ssh = obj_bmc.ssh
-                str_rsp = bmc_ssh.send_command_wait_string(str_command = 'ipmitool -I lanplus -H localhost -U {} -P {} fru print 0 {}'.format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)), wait = '$', int_time_out = 3, b_with_buff = False)
+                str_rsp = bmc_ssh.send_command_wait_string(str_command='ipmitool -I lanplus -H localhost -U {} -P {} fru print 0 {}'.
+                                                           format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)),
+                                                           wait='$',
+                                                           int_time_out=3,
+                                                           b_with_buff=False)
 
                 fru = {}
                 for item in str_rsp.split('\n'):
                     key = item.split(': ')[0].strip()
                     value = item.split(': ')[-1].strip()
                     fru[key] = value
+
+                # If ipmitool not response as expected, key shall be lost
+                # and this test shall be blocked on this node
+                if 'Product Name' not in fru:
+                    self.result(BLOCK, 'Node {} fail to get fru print information, '
+                                       'response of ipmitool is:\n{}'.
+                                format(obj_node.get_name(), str_rsp))
+                    continue
 
                 try:
                     node_lan_channel = self.data[fru['Product Name']]
@@ -43,7 +55,11 @@ class T33249_idic_IPMILocalLanPrint(CBaseCase):
                     """
                                 .format(e, e, self.__class__.__name__))
                 else:
-                    str_rsp = bmc_ssh.send_command_wait_string(str_command = 'ipmitool -I lanplus -H localhost -U {} -P {} lan print {} {}'.format(obj_bmc.get_username(), obj_bmc.get_password(), node_lan_channel, chr(13)), wait = '$', int_time_out = 3, b_with_buff = False)
+                    str_rsp = bmc_ssh.send_command_wait_string(str_command='ipmitool -I lanplus -H localhost -U {} -P {} lan print {} {}'.
+                                                               format(obj_bmc.get_username(), obj_bmc.get_password(), node_lan_channel, chr(13)),
+                                                               wait='$',
+                                                               int_time_out=3,
+                                                               b_with_buff = False)
 
                     self.log('INFO', 'rsp: \n{}'.format(str_rsp))
                     is_match = re.search("failed", str_rsp)

--- a/case/infrasim/virtual_node/T33250_idic_IPMILocalSensorList.py
+++ b/case/infrasim/virtual_node/T33250_idic_IPMILocalSensorList.py
@@ -23,7 +23,11 @@ class T33250_idic_IPMILocalSensorList(CBaseCase):
 
                 obj_bmc = obj_node.get_bmc()
                 bmc_ssh = obj_bmc.ssh
-                str_rsp = bmc_ssh.send_command_wait_string(str_command = 'ipmitool -I lanplus -H localhost -U {} -P {} sensor list {}'.format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)), wait = '$', int_time_out = 3, b_with_buff = False)
+                str_rsp = bmc_ssh.send_command_wait_string(str_command='ipmitool -I lanplus -H localhost -U {} -P {} sensor list {}'.
+                                                           format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)),
+                                                           wait='$',
+                                                           int_time_out=3,
+                                                           b_with_buff=False)
                 self.log('INFO', 'rsp: \n{}'.format(str_rsp))
                 is_match = re.search("failed", str_rsp)
                 if is_match == None:

--- a/case/infrasim/virtual_node/T33251_idic_IPMILocalSelList.py
+++ b/case/infrasim/virtual_node/T33251_idic_IPMILocalSelList.py
@@ -23,7 +23,11 @@ class T33251_idic_IPMILocalSelList(CBaseCase):
 
                 obj_bmc = obj_node.get_bmc()
                 bmc_ssh = obj_bmc.ssh
-                str_rsp = bmc_ssh.send_command_wait_string(str_command = 'ipmitool -I lanplus -H localhost -U {} -P {} sel list {}'.format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)), wait = '$', int_time_out = 3, b_with_buff = False)
+                str_rsp = bmc_ssh.send_command_wait_string(str_command='ipmitool -I lanplus -H localhost -U {} -P {} sel list {}'.
+                                                           format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)),
+                                                           wait='$',
+                                                           int_time_out=3,
+                                                           b_with_buff = False)
                 self.log('INFO', 'rsp: \n{}'.format(str_rsp))
                 is_match = re.search("failed", str_rsp)
                 if is_match == None:

--- a/case/infrasim/virtual_node/T33252_idic_IPMILocalSdrList.py
+++ b/case/infrasim/virtual_node/T33252_idic_IPMILocalSdrList.py
@@ -23,7 +23,11 @@ class T33252_idic_IPMILocalSdrList(CBaseCase):
 
                 obj_bmc = obj_node.get_bmc()
                 bmc_ssh = obj_bmc.ssh
-                str_rsp = bmc_ssh.send_command_wait_string(str_command = 'ipmitool -I lanplus -H localhost -U {} -P {} sdr list {}'.format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)), wait = '$', int_time_out = 3, b_with_buff = False)
+                str_rsp = bmc_ssh.send_command_wait_string(str_command='ipmitool -I lanplus -H localhost -U {} -P {} sdr list {}'.
+                                                           format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)),
+                                                           wait='$',
+                                                           int_time_out=3,
+                                                           b_with_buff = False)
                 self.log('INFO', 'rsp: \n{}'.format(str_rsp))
                 is_match = re.search("failed", str_rsp)
                 if is_match == None:

--- a/case/infrasim/virtual_node/T36698_idic_IPMILocalUserList.py
+++ b/case/infrasim/virtual_node/T36698_idic_IPMILocalUserList.py
@@ -23,8 +23,16 @@ class T36698_idic_IPMILocalUserList(CBaseCase):
 
                 obj_bmc = obj_node.get_bmc()
                 bmc_ssh = obj_bmc.ssh
-                str_rsp = bmc_ssh.send_command_wait_string(str_command = 'ipmitool -I lanplus -H localhost -U {} -P {} user list {}'.format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)), wait = '$', int_time_out = 3, b_with_buff = False)
-                str_rsp += bmc_ssh.send_command_wait_string(str_command = 'ipmitool -I lanplus -H localhost -U {} -P {} user summary 0 {}'.format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)), wait = '$', int_time_out = 3, b_with_buff = False)
+                str_rsp = bmc_ssh.send_command_wait_string(str_command='ipmitool -I lanplus -H localhost -U {} -P {} user list {}'.
+                                                           format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)),
+                                                           wait='$',
+                                                           int_time_out=3,
+                                                           b_with_buff=False)
+                str_rsp += bmc_ssh.send_command_wait_string(str_command='ipmitool -I lanplus -H localhost -U {} -P {} user summary 0 {}'.
+                                                            format(obj_bmc.get_username(), obj_bmc.get_password(), chr(13)),
+                                                            wait='$',
+                                                            int_time_out=3,
+                                                            b_with_buff = False)
 
                 self.log('INFO', 'rsp: \n{}'.format(str_rsp))
                 is_match = re.search("failed", str_rsp)

--- a/case/infrasim/virtual_node/T46194_idic_QEMUBootAutomatically.py
+++ b/case/infrasim/virtual_node/T46194_idic_QEMUBootAutomatically.py
@@ -23,7 +23,10 @@ class T46194_idic_QEMUBootAutomatically(CBaseCase):
 
                 obj_bmc = obj_node.get_bmc()
                 bmc_ssh = obj_bmc.ssh
-                str_rsp = bmc_ssh.send_command_wait_string(str_command = 'ps | grep "qemu"'+chr(13), wait = '$', int_time_out = 3, b_with_buff = False)
+                str_rsp = bmc_ssh.send_command_wait_string(str_command='ps | grep "qemu"'+chr(13),
+                                                           wait='$',
+                                                           int_time_out=3,
+                                                           b_with_buff=False)
 
                 self.log('INFO', 'rsp: \n{}'.format(str_rsp))
 


### PR DESCRIPTION
For all test that log into vNode shell, if ipmitool fail to get
"fru print", this node shall fail to get specific data for test.

In this fix, test is blocked in such condition.