### PR TITLE
enhance/support_external_requirement_file

### DIFF
--- a/utilities/Util_Manipulate.py
+++ b/utilities/Util_Manipulate.py
@@ -75,7 +75,10 @@ def conf_parse():
     global CONF_DATA
     global VRACKSYSTEM_INFO
     global GEN_CONF
-    conf_file_path = "../configure/{}".format(CONF_FILE)
+    if os.path.isfile(CONF_FILE):
+        conf_file_path = CONF_FILE
+    else:
+        conf_file_path = "../configure/{}".format(CONF_FILE)
     try:
         with open(conf_file_path) as configure:
             CONF_DATA = json.load(configure)


### PR DESCRIPTION
Now -f can figure out a path for a stack requirement file, instead
of a file in configure/ only before.