### PR TITLE
enhance/non_pdu_switch_support

### DIFF
--- a/configure/stack_requirement.json
+++ b/configure/stack_requirement.json
@@ -14,12 +14,13 @@
 
     "vRacks": {
         "vRack1": {
+            "hypervisor": "ESXi1",
             "vPDU": 1,
             "vSwitch": 0,
             "vNode": {
-		"quanta_t41":1,
-		"quanta_d51":1,
-		"s2600kp":1
+                "quanta_t41":1,
+                "quanta_d51":1,
+                "s2600kp":1
             }
         }
     }

--- a/utilities/Util_Manipulate.py
+++ b/utilities/Util_Manipulate.py
@@ -514,8 +514,8 @@ def deploy_vracks():
         GEN_CONF["vRacks"][-1]["name"] = key
         try:
             hypervisor = vrack["hypervisor"]
-            vpdu_num = vrack["vPDU"]
-            vswitch_num = vrack["vSwitch"]
+            vpdu_num = vrack.get("vPDU", 0)
+            vswitch_num = vrack.get("vSwitch", 0)
             vnodes = vrack["vNode"]
             for node in vnodes.keys():
                 if node.lower() not in NODES_TYPE:


### PR DESCRIPTION
If no vPDU and vSwitch information is provided in stack requirement,
their count will be set to 0 instead of raise an exception.