### PR TITLE
hotfix/ac_cycle_node_if_not_alive

### DIFF
--- a/case/CBaseCase.py
+++ b/case/CBaseCase.py
@@ -766,9 +766,11 @@ class CBaseCase(CLogger):
                 # BMC is not on, power on the virtual node in first loop
                 if ret != 0:
                     if i == 0:
-                        self.log('WARNING', 'Node {} vBMC fail to response IOL command, ret: {}, AC on the node'.
+                        self.log('WARNING', 'Node {} vBMC fail to response IOL command, ret: {}, AC cycle the node ...'.
                                  format(obj_node.get_name(), ret))
                         if obj_node._has_power_control():
+                            obj_node.power_off()
+                            time.sleep(10)
                             obj_node.power_on()
                         else:
                             self.result(BLOCK, 'Node {} vBMC doesn\'t response IOL command, ret: {}'.


### PR DESCRIPTION
AC off then AC on if a node's IPMI stack is not alive.

*Background*
Previous implementation is pending on PDU feature:
If PDU gets the node in On status, but node is off by externel
operation, PDU can't immediately power on node. It has to off
first to match node's current status then operate node to power
on.