### PR TITLE
bugfix/PDU_shell

### DIFF
--- a/case/CBaseCase.py
+++ b/case/CBaseCase.py
@@ -942,7 +942,10 @@ class CBaseCase(CLogger):
         obj_ssh.set_log(1, True)
         if not obj_ssh.is_connected():
             obj_ssh.connect()
-        str_rsp = obj_ssh.send_command_wait_string('help' + chr(13), '[CONFIG] [HELP] [IP] [MAP] [PASS] [PASSWORD] [SAVE] [VPDU]', b_with_buff=False)
+        obj_ssh.send_command_wait_string(str_command='help' + chr(13),
+                                         wait='[CONFIG] [HELP] [IP] [MAP] [PASS] [PASSWORD] [SAVE] [VPDU] \r\n(vPDU)',
+                                         int_time_out=10,
+                                         b_with_buff=False)
 
         return
 


### PR DESCRIPTION
Fix the random PDU test failure issue on busy network traffict.

Init PDU remote shell to the first prompt, then release control
to test case.