### PR TITLE
bugfix/identity_product_name

### DIFF
--- a/case/infrasim/virtual_bmc/T33226_idic_vBMCAddSelThroughCommand.py
+++ b/case/infrasim/virtual_bmc/T33226_idic_vBMCAddSelThroughCommand.py
@@ -24,7 +24,7 @@ class T33226_idic_vBMCAddSelThroughCommand(CBaseCase):
                 obj_bmc = obj_node.get_bmc()
 
                 # Get product name from FRU data.
-                ret, rsp = obj_node.get_bmc().ipmi.ipmitool_standard_cmd('fru print')
+                ret, rsp = obj_node.get_bmc().ipmi.ipmitool_standard_cmd('fru print 0')
                 # Test fail if this nodes ipmi can't response
                 if ret != 0:
                     self.result(BLOCK, 'Node {} on rack {} fail to response ipmitool fru print'.

--- a/case/infrasim/virtual_bmc/T33227_idic_vBMCAddSelThroughSensor.py
+++ b/case/infrasim/virtual_bmc/T33227_idic_vBMCAddSelThroughSensor.py
@@ -23,7 +23,7 @@ class T33227_idic_vBMCAddSelThroughSensor(CBaseCase):
                 obj_bmc = obj_node.get_bmc()
 
                 # Get product name from FRU data.
-                ret, rsp = obj_node.get_bmc().ipmi.ipmitool_standard_cmd('fru print')
+                ret, rsp = obj_node.get_bmc().ipmi.ipmitool_standard_cmd('fru print 0')
                 # Test fail if this nodes ipmi can't response
                 if ret != 0:
                     self.result(BLOCK, 'Node {} on rack {} fail to response ipmitool fru print'.

--- a/case/infrasim/virtual_bmc/T36706_idic_vBMCDataEmulation.py
+++ b/case/infrasim/virtual_bmc/T36706_idic_vBMCDataEmulation.py
@@ -24,7 +24,7 @@ class T36706_idic_vBMCDataEmulation(CBaseCase):
                 obj_bmc = obj_node.get_bmc()
 
                 # Get product name from FRU data.
-                ret, rsp = obj_node.get_bmc().ipmi.ipmitool_standard_cmd('fru print')
+                ret, rsp = obj_node.get_bmc().ipmi.ipmitool_standard_cmd('fru print 0')
                 # Test fail if this nodes ipmi can't response
                 if ret != 0:
                     self.result(BLOCK, 'Node {} on rack {} fail to response ipmitool fru print'.

--- a/case/infrasim/virtual_bmc/T46139_idic_IPMISIMSensorAccessible.py
+++ b/case/infrasim/virtual_bmc/T46139_idic_IPMISIMSensorAccessible.py
@@ -25,7 +25,7 @@ class T46139_idic_IPMISIMSensorAccessible(CBaseCase):
                 bmc_obj = obj_node.get_bmc()
 
                 # Get product name from FRU data.
-                ret, rsp = obj_node.get_bmc().ipmi.ipmitool_standard_cmd('fru print')
+                ret, rsp = obj_node.get_bmc().ipmi.ipmitool_standard_cmd('fru print 0')
                 # Test fail if this nodes ipmi can't response
                 if ret != 0:
                     self.result(BLOCK, 'Node {} on rack {} fail to response ipmitool fru print'.

--- a/case/infrasim/virtual_bmc/T46140_idic_IPMISIMSelAccessible.py
+++ b/case/infrasim/virtual_bmc/T46140_idic_IPMISIMSelAccessible.py
@@ -23,7 +23,7 @@ class T46140_idic_IPMISIMSelAccessible(CBaseCase):
                 obj_bmc = obj_node.get_bmc()
 
                 # Get product name from FRU data.
-                ret, rsp = obj_node.get_bmc().ipmi.ipmitool_standard_cmd('fru print')
+                ret, rsp = obj_node.get_bmc().ipmi.ipmitool_standard_cmd('fru print 0')
                 # Test fail if this nodes ipmi can't response
                 if ret != 0:
                     self.result(BLOCK, 'Node {} on rack {} fail to response ipmitool fru print'.


### PR DESCRIPTION
Updated cases shall get product name via fru print 0.
FRU 0 is motherboard, and its product name identify the product.

Previously, it capture product name from all printed fru and may
mistake other fru's product name, for example power supplies.