### PR TITLE
bugfix/T36713_lack_one_attribute_in_string_format

### DIFF
--- a/case/infrasim/virtual_pdu/T36713_idic_ControlNodePower.py
+++ b/case/infrasim/virtual_pdu/T36713_idic_ControlNodePower.py
@@ -83,7 +83,7 @@ class T36713_idic_ControlNodePower(CBaseCase):
                 # BMC is not on, power on the virtual node in first loop
                 if ret != 0:
                     self.log('WARNING', 'Node {} vBMC doesn\'t response, ret: {}, retry...'.
-                             format(obj_node.get_name()))
+                             format(obj_node.get_name(), ret))
                     time.sleep(int_gap)
                     continue
                 # System power is not on, do ipmi power on

--- a/lib/main.py
+++ b/lib/main.py
@@ -206,15 +206,17 @@ def run_in_command_line_mode():
     # Case list by -l, test list file
     list_file = obj_options.str_case_list
     if list_file:
-        msg = 'Include cases in list file(%s) into task file' % list_file
-        Env.log('INFO', msg)
         # parse the file and add to list_case
         for one_list in list_file.split(','):
+            msg = 'Include cases in list file(%s) into task file' % list_file
+            Env.log('INFO', msg)
             if not os.path.isfile(one_list):
                 Env.log('WARNING', 'Case list file(%s) not found' % one_list)
             else:
                 lines = open(one_list, 'r').read().splitlines()
                 for i in lines:
+                    if not i.strip():
+                        continue
                     if i.startswith('#' or '/'):
                         # commented out. ignore.
                         continue


### PR DESCRIPTION
Print the varaible "ret" in error message. This failure escaped
pylint check.