### PR TITLE
Change history checking order, change CRLF to LF

### DIFF
--- a/case/infrasim/stress/T78170_idic_IPMISIMHistory30Commands.py
+++ b/case/infrasim/stress/T78170_idic_IPMISIMHistory30Commands.py
@@ -58,13 +58,13 @@ class T78170_idic_IPMISIMHistory30Commands(CBaseCase):
 
                 #lines[count-1] is 'IPMI_SIM'
                 #lines[count-2] is '\r'
-                p_sensor = r'\d*\ssel\r'#pattern for lines[count-3]
+                p_sensor = r'\d*\ssel\r'#pattern for lines[count-5]
                 p_help_sensor = r'\d*\ssensor\r'#pattern for lines[count-4]
-                p_help = r'\d*\shelp\r'#pattern for lines[count-5]
+                p_help = r'\d*\shelp\r'#pattern for lines[count-3]
 
-                if re.search(p_sensor, lines[count-3])  \
+                if re.search(p_sensor, lines[count-5])  \
                         and re.search(p_help_sensor, lines[count-4])  \
-                        and re.search(p_help, lines[count-5]) :
+                        and re.search(p_help, lines[count-3]) :
                     self.log('INFO', 'History from Node:{} .Rack is {}, Node is {}, BMC IP is: {}'.
                             format(str_rsp, obj_node.get_name(),obj_node.get_name(), bmc_obj.get_ip()))
                 else:


### PR DESCRIPTION
1) Change line separator from CRLF to LF
2) Since the command order is 40* sensor info -> sel -> sensor -> help,
   pattern for lines[count-5] is sel
   pattern for lines[count-4] is sensor
   pattern for lines[count-3] is help