### PR TITLE
bugfix/activate_sol_on_bmc_network

### DIFF
--- a/idic/stack/Node.py
+++ b/idic/stack/Node.py
@@ -135,8 +135,9 @@ class CNode(CDevice):
             return
 
         # Connect
-        self.ssh.send_command('ipmitool -I lanplus -H localhost -U {} -P {} sol activate{}'.
-                              format(self.bmc.get_username(),
+        self.ssh.send_command('ipmitool -I lanplus -H {} -U {} -P {} sol activate{}'.
+                              format(self.bmc.get_ip(),
+                                     self.bmc.get_username(),
                                      self.bmc.get_password(),
                                      chr(13)))
 


### PR DESCRIPTION
Puffer activate SOL in this step:

1. SSH to infrasim environment
2. Use SSH library to send command `sol activate`
3. Send power cycle command to target BMC
4. Capture any output from the SSH session

In step 2, puffer hard code to send the command with option `-H localhost`. This is OK if BMC listen on all port.
But this won't work if vBMC is listening on certain network specified in infrasim.yml.