### PR TITLE
Bugfix: Apply new yml structure and s2600wtt added in T72404

### DIFF
--- a/case/infrasim/virtual_bmc/T72404_idic_IPMIConsoleSensorAutoMode.json
+++ b/case/infrasim/virtual_bmc/T72404_idic_IPMIConsoleSensorAutoMode.json
@@ -5,6 +5,7 @@
         "D51B-2U (dual 1G LoM)":"0xaa",
         "S2600KP":"0x24",
         "S2600TP":"0x24",
+        "S2600WTT":"0x20",
         "PowerEdge C6320":"0xb1",
         "":"0x04",
         "PowerEdge R730": "0x04",

--- a/case/infrasim/virtual_node/T97939_idic_KCSTest.py
+++ b/case/infrasim/virtual_node/T97939_idic_KCSTest.py
@@ -48,11 +48,9 @@ class T97939_idic_KCSTest(CBaseCase):
         str_node_name = node.get_instance_name()
         payload = [
             {
-                "controller": {
-                    "type": "ahci",
-                    "max_drive_per_controller": 6,
-                    "drives": [{"size": 8, "file": dst_path}]
-                }
+                "type": "ahci",
+                "max_drive_per_controller": 6,
+                "drives": [{"size": 8, "file": dst_path}]
             }
         ]
         node.update_instance_config(str_node_name, payload, "compute", "storage_backend")

--- a/idic/stack/Node.py
+++ b/idic/stack/Node.py
@@ -206,8 +206,11 @@ class CNode(CDevice):
                                                 wait='~$')
 
         list_name = list(set(p_name.findall(rsp)))
-        if len(list_name) == 1:
+        active_num = len(list_name)
+        if active_num == 1:
             return list_name[0]
+        elif active_num == 0:
+            raise Exception("Infrasim node is not running on {}".format(self.ip))
         else:
             raise Exception("Multiple infrasim instances {} are detected on {}. "
                             "This is not supported yet.".


### PR DESCRIPTION
1. Remove "controller" key from node info.
2. Add s2600wtt in T72404 json file otherwise it will pop up key error.
3. Identify error type in Node.py "get_instance_name".