### PR TITLE
Refine IP pool generating. Let docker Vagrant use same IP source file, ip.txt

### DIFF
--- a/utilities/CreateAnsibleInventory.py
+++ b/utilities/CreateAnsibleInventory.py
@@ -37,16 +37,14 @@ path_template = os.sep.join(
 
 
 def load_ip_pool(path):
-    global p_admin_ip
     with open(path, 'r') as fp:
         text = fp.read()
 
-    if re.search(r'docker\.log$',path):
-        p_admin_ip = p_admin_docker_ip
-    else:
-        p_admin_ip = p_admin_vagrant_ip
-    r = re.compile(p_admin_ip)
+    r = re.compile(p_admin_vagrant_ip)
     list_ip_pool = r.findall(text)
+    if list_ip_pool == []:
+        r = re.compile(p_admin_docker_ip)
+        list_ip_pool = r.findall(text)
 
     return list_ip_pool
 


### PR DESCRIPTION
It should resolve current docker ci test failure of empty test stack.
@fub2 @turtle-fly @XiaowenJiang @chenc52 @chenge3 @weia5-emc @xiar 