### PR TITLE
Add try exception and log result for get_instance_name failure, jenkins will mark red

### DIFF
--- a/case/infrasim/virtual_node/T130052_idic_ESXiTest.py
+++ b/case/infrasim/virtual_node/T130052_idic_ESXiTest.py
@@ -36,9 +36,11 @@ class T130052_idic_ESXiTest(CBaseCase):
         print node.ssh.send_command_wait_string(str_command="echo infrasim | sudo -S rm -f /tmp/esxi6p3-1.qcow2"+chr(13), wait="~$")
 
         dst_path = node.send_file(os.environ["HOME"]+"/images/esxi6p3-1.qcow2", "/tmp/esxi6p3-1.qcow2")
-        #dst_path = "/tmp/esxi6p3-1.qcow2"
 
-        str_node_name = node.get_instance_name()
+        try:
+            str_node_name = node.get_instance_name()
+        except:
+            self.result(BLOCK, "Failed to get infrasim instance.")
 
         payload = [
             {
@@ -88,7 +90,10 @@ class T130052_idic_ESXiTest(CBaseCase):
             return
 
     def esxcli_test(self, node):
-        str_node_name = node.get_instance_name()
+        try:
+            str_node_name = node.get_instance_name()
+        except:
+            self.result(BLOCK, "Failed to get infrasim instance.")
         qemu_config = node.get_instance_config(str_node_name)
         qemu_first_mac = qemu_config["compute"]["networks"][0]["mac"].lower()
         # Get qemu IP

--- a/case/infrasim/virtual_node/T130052_idic_ESXiTest.py
+++ b/case/infrasim/virtual_node/T130052_idic_ESXiTest.py
@@ -41,6 +41,7 @@ class T130052_idic_ESXiTest(CBaseCase):
             str_node_name = node.get_instance_name()
         except:
             self.result(BLOCK, "Failed to get infrasim instance.")
+            return
 
         payload = [
             {
@@ -80,7 +81,7 @@ class T130052_idic_ESXiTest(CBaseCase):
         if ret != 0:
             self.result(BLOCK, "Fail to set instance {} on {} boot from disk".
                         format(str_node_name, node.get_ip()))
-
+            return
         # Reboot to esxi img
         self.log('INFO', 'Power cycle guest to boot to disk on {}...'.format(node.get_name()))
         ret, rsp = node.get_bmc().ipmi.ipmitool_standard_cmd("chassis power cycle")
@@ -94,6 +95,7 @@ class T130052_idic_ESXiTest(CBaseCase):
             str_node_name = node.get_instance_name()
         except:
             self.result(BLOCK, "Failed to get infrasim instance.")
+            return
         qemu_config = node.get_instance_config(str_node_name)
         qemu_first_mac = qemu_config["compute"]["networks"][0]["mac"].lower()
         # Get qemu IP
@@ -139,6 +141,7 @@ class T130052_idic_ESXiTest(CBaseCase):
 
         if match_index == 0:
             self.result(BLOCK, "Tried ssh to guest on {} for {} times already, but still failed.".format(node.get_name(), times))
+            return
         else:
             self.esx_test_ipmi_fru(node)
             self.esx_test_storage_device(node)

--- a/case/infrasim/virtual_node/T97939_idic_KCSTest.py
+++ b/case/infrasim/virtual_node/T97939_idic_KCSTest.py
@@ -45,7 +45,11 @@ class T97939_idic_KCSTest(CBaseCase):
 
     def boot_to_disk(self, node):
         dst_path = node.send_file("image/kcs.img", "kcs.img")
-        str_node_name = node.get_instance_name()
+        try:
+            str_node_name = node.get_instance_name()
+        except:
+            self.result(BLOCK, "Failed to get infrasim instance.")
+
         payload = [
             {
                 "type": "ahci",
@@ -71,7 +75,10 @@ class T97939_idic_KCSTest(CBaseCase):
             return
 
     def kcs_test(self, node):
-        str_node_name = node.get_instance_name()
+        try:
+            str_node_name = node.get_instance_name()
+        except:
+            self.result(BLOCK, "Failed to get infrasim instance.")
         qemu_config = node.get_instance_config(str_node_name)
         qemu_first_mac = qemu_config["compute"]["networks"][0]["mac"].lower()
         # Get qemu IP

--- a/case/infrasim/virtual_node/T97939_idic_KCSTest.py
+++ b/case/infrasim/virtual_node/T97939_idic_KCSTest.py
@@ -49,6 +49,7 @@ class T97939_idic_KCSTest(CBaseCase):
             str_node_name = node.get_instance_name()
         except:
             self.result(BLOCK, "Failed to get infrasim instance.")
+            return
 
         payload = [
             {
@@ -65,6 +66,7 @@ class T97939_idic_KCSTest(CBaseCase):
         if ret != 0:
             self.result(BLOCK, "Fail to set instance {} on {} boot from disk".
                         format(str_node_name, node.get_ip()))
+            return
 
         # Reboot to kcs.img
         self.log('INFO', 'Power cycle guest to boot to disk on {}...'.format(node.get_name()))
@@ -79,6 +81,7 @@ class T97939_idic_KCSTest(CBaseCase):
             str_node_name = node.get_instance_name()
         except:
             self.result(BLOCK, "Failed to get infrasim instance.")
+            return
         qemu_config = node.get_instance_config(str_node_name)
         qemu_first_mac = qemu_config["compute"]["networks"][0]["mac"].lower()
         # Get qemu IP


### PR DESCRIPTION
Applying better solution to mark Jenkins red upon get_instance_name exception, it will also record the exception in Junit file which Jenkins is analyzing puffer result against.
So, not redirecting puffer exception in jenkins now.

@InfraSIM/infrasim_dev 