### PR TITLE
Add debug mode option for stop test on error

### DIFF
--- a/case/CBaseCase.py
+++ b/case/CBaseCase.py
@@ -523,6 +523,11 @@ class CBaseCase(CLogger):
         if str_result == FAIL:
             self.log('ERROR', 'Test case failed: \n%s' % str_info)
             self.list_error_code.append('\n{}'.format(str_info))
+            if Env.str_debug == "on":
+                # the self._deconfig is meaningful here for an elegant ending.
+                # It won't stop/destory/restart node, mainly release connections of ssh, rest agent and iol
+                self._deconfig()
+                os._exit(0)
         elif str_result == SKIP:
             self.log('WARNING', 'Test case is skipped: \n%s' % str_info)
             self.list_error_code.append('\n{}'.format(str_info))

--- a/lib/Env.py
+++ b/lib/Env.py
@@ -46,6 +46,7 @@ str_testrail_root = ''
 str_testrail_username = ''
 str_testrail_password = ''
 str_alias = ''
+str_debug = 'off'
 
 if not os.path.isfile(str_config_file):
     msg = 'conf.xml not found. Please create one based on conf.xml ' \
@@ -275,7 +276,7 @@ def load_hwimo(str_hwimo_ip, str_hwimo_username, str_hwimo_password):
         errmsg = 'Unexpected exception happened when loading HWIMO {0}:{1}@{2}, trace back: \n{3}'.\
             format(str_hwimo_username, str_hwimo_password, str_hwimo_ip, traceback.format_exc())
         log('ERROR', errmsg)
-        
+
  
 if __name__ == '__main__':
     print 'Env module is not runnable'

--- a/lib/TestExecutor.py
+++ b/lib/TestExecutor.py
@@ -917,7 +917,8 @@ class CTestExecutor(CLogger):
                         case_uuid)
                 str_line = str_line.replace('$CASEHYPERLINK', case_log_folder)
 
-                str_case_result = obj_xmlnode_case.find('result').text.lower()
+                if obj_xmlnode_case.find('result').text:
+                    str_case_result = obj_xmlnode_case.find('result').text.lower()
 
                 if str_case_result == 'pass':
                     int_pass_case_number += 1

--- a/lib/main.py
+++ b/lib/main.py
@@ -99,6 +99,11 @@ def load_environment():
     else:
         Env.log('WARNING', 'Both stack and HWIMO information are missing')
 
+    if obj_options.str_debug:
+        Env.log('INFO', 'Will stop on error, ' \
+                'when a case fails, Puffer is going to stop execution of the case and won\'t ' \
+                ' execute any other cases.')
+        Env.str_debug = obj_options.str_debug
     # Configure email server
     try:
         obj_mail_node = Env.obj_config_manager.get_smpt_server_node()
@@ -373,6 +378,10 @@ def parse_options():
                      dest='dedup', default=False,
                      help='Set if duplicated cases should be removed '
                           'from test list.')
+    group.add_option('-d', '--debug', action='store',
+                     dest='str_debug', default="off",
+                     help='Set debug mode to "on" if puffer should stop execution at a ' \
+                          'failing case and won\'t execute any more cases. ')
     parser.add_option_group(group)
     
     # Device config


### PR DESCRIPTION
@InfraSIM/infrasim_dev 
This feature is for puffer test case failure debugging.
For example, if you turn the debug mode on, see highlighed below, then it will stop the first failed case.
                 sudo python puffer.py _**-d on**_ --stack=stack.json -s infrasim

User cases:
1. If a case's failure is related to other tests, we wan't to run a bunch of tests and still only want it stop at the failing case without execute any more cases which seems like waste of time.
2. If a case fails randomly, you can run the test again and again but stops when it fails within one command line like:  sudo python puffer.py -d on --stack=stack.json -c 33252,33252,33252
3. If a case fails at a step, and you want the case stops right at that step when failure happens and don't execute any more steps.
  
_Note: deconfig is meaningful here for an elegant ending. It won't stop/destory/restart node, mainly release connections of ssh, rest agent and iol. So when exit testing, deconfig is also called.
