### PR TITLE
Fix ci node issue, all nodes are dell r730 instead of 9 different nodes

### DIFF
--- a/utilities/CreateTestStack.py
+++ b/utilities/CreateTestStack.py
@@ -253,10 +253,17 @@ def start_node():
     global ssh_password
 
     cmd = "ansible {} -i {} -m shell -a \"echo {} | " \
+          "setsid sudo -S infrasim node destroy\"".\
+        format(full_group, inventory_path, ssh_password)
+    run_command(cmd)
+    time.sleep(3)
+
+    cmd = "ansible {} -i {} -m shell -a \"echo {} | " \
           "setsid sudo -S infrasim node start\"".\
         format(full_group, inventory_path, ssh_password)
     _, rsp = run_command(cmd)
     print rsp
+
     # Verify operations on all nodes are successful
     for hosts_of_this_kind in hosts.values():
         for host in hosts_of_this_kind:


### PR DESCRIPTION
When deploy and prepare 9 different node via ansible, there miss a step to destroy origin nodes before starting nodes. And node type are all still as default type, dell r730.
So here add node destroying to let the updated node type to take effect.
@InfraSIM/infrasim_dev @chenge3 @chenc52 @XiaowenJiang @xiar 