### PR TITLE
Add sync ubuntu img folder to vagrantfile template

### DIFF
--- a/doc/template_Vagrantfile
+++ b/doc/template_Vagrantfile
@@ -14,6 +14,8 @@ Vagrant.configure("2") do |config|
       subconfig.ssh.username = 'infrasim'
       subconfig.ssh.password = 'infrasim'
       subconfig.ssh.insert_key = true
+      subconfig.vm.synced_folder "../../../image", "/mnt", disabled: false
+      subconfig.vm.synced_folder ".", "/vagrant", disabled: true
       subconfig.vm.provision "shell", inline: $script, privileged: false
     end
 


### PR DESCRIPTION
Add the sync folder will make infrasim-compute-ci-test
deploy vagrant-vms with ubuntu image in /mnt folder

Signed-off-by: Echo Cheng <echo.cheng@emc.com>

@chenge3 @xiar @fub2 @XiaowenJiang 